### PR TITLE
Fix for getSignedUrl

### DIFF
--- a/src/s3.ts
+++ b/src/s3.ts
@@ -77,6 +77,7 @@ export class S3UploadResult extends PdfResult {
 
   constructor(path: string, options: S3UploadOptions, buffer?: Buffer) {
     super();
+    this.s3Options = options.credentials;
     this.bucket = options.bucket;
     this.path = path;
     this.name = options.name;


### PR DESCRIPTION
Without credentials, getSignedUrl still returns a url, but it results in Access Denied.

I'm not sure why the existing s3 integration test was passing. Am I missing something?