### PR TITLE
Added css style hint for background colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ There are some caveats and limitations to be aware of:
    It is not possible to use styles from the page in the headers and footers.
  * Headers and footers do not support external resources, including stylesheets and images. Inline styles, and
    images with inline base64 content, are supported.
+ * `-webkit-print-color-adjust:exact;` should be added to any styles that rely on background colors.
 
 ## Using DocRaptor
 

--- a/src/docraptor.spec.ts
+++ b/src/docraptor.spec.ts
@@ -15,7 +15,7 @@ describe('pdfs - docraptor', function() {
     });
     const buffer = await pdf.toBuffer();
     expect(buffer.byteLength).to.gt(1000);
-    expect(buffer.slice(0, 8).toString('utf-8')).to.eq('%PDF-1.4');
+    expect(buffer.slice(0, 7).toString('utf-8')).to.eq('%PDF-1.'); // %PDF-1.4 or %PDF-1.5
   }).timeout(30000);
 
   it('should generate a PDF from a URL', async function() {
@@ -29,6 +29,6 @@ describe('pdfs - docraptor', function() {
     });
     const buffer = await pdf.toBuffer();
     expect(buffer.byteLength).to.gt(1000);
-    expect(buffer.slice(0, 8).toString('utf-8')).to.eq('%PDF-1.4');
+    expect(buffer.slice(0, 7).toString('utf-8')).to.eq('%PDF-1.'); // %PDF-1.4 or %PDF-1.5
   }).timeout(30000);
 });


### PR DESCRIPTION
Added a bullet in the readme for how to enable background colours in the header and footer sections.